### PR TITLE
Add attribution links to icon svg files

### DIFF
--- a/resources/views/components/icons/github.blade.php
+++ b/resources/views/components/icons/github.blade.php
@@ -1,3 +1,4 @@
+{{-- https://lucide.dev/icons/github --}}
 <svg
     xmlns="http://www.w3.org/2000/svg"
     width="24"

--- a/resources/views/components/icons/globe.blade.php
+++ b/resources/views/components/icons/globe.blade.php
@@ -1,3 +1,4 @@
+{{-- https://lucide.dev/icons/globe --}}
 <svg
     xmlns="http://www.w3.org/2000/svg"
     width="24"

--- a/resources/views/components/icons/radar.blade.php
+++ b/resources/views/components/icons/radar.blade.php
@@ -1,3 +1,4 @@
+{{-- https://lucide.dev/icons/radar --}}
 <svg
     xmlns="http://www.w3.org/2000/svg"
     width="24"

--- a/resources/views/components/icons/rss.blade.php
+++ b/resources/views/components/icons/rss.blade.php
@@ -1,3 +1,4 @@
+{{-- https://lucide.dev/icons/rss --}}
 <svg
     xmlns="http://www.w3.org/2000/svg"
     width="24"

--- a/resources/views/components/icons/youtube.blade.php
+++ b/resources/views/components/icons/youtube.blade.php
@@ -1,3 +1,4 @@
+{{-- https://lucide.dev/icons/youtube --}}
 <svg
     xmlns="http://www.w3.org/2000/svg"
     width="24"


### PR DESCRIPTION
This PR adds attribution links to the svg icon blade templates that were missing them.