### PR TITLE
Allow feeds to be empty

### DIFF
--- a/src/Transform/Atom.php
+++ b/src/Transform/Atom.php
@@ -18,6 +18,10 @@ final class Atom
      */
     private function timestamp(): string
     {
+        if ($this->articles->isEmpty()) {
+            return now()->toAtomString();
+        }
+
         return $this->articles->pluck('published_at')->max()->toAtomString();
     }
 


### PR DESCRIPTION
This PR updates the Atom transformer so that it will still render when no entries are available.