### PR TITLE
Remove article image tracking and embed them in content instead

### DIFF
--- a/database/migrations/2025_01_21_003314_remove_article_image.php
+++ b/database/migrations/2025_01_21_003314_remove_article_image.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.]
+     */
+    public function up(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->dropColumn('image');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/src/Article.php
+++ b/src/Article.php
@@ -14,7 +14,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $key
  * @property string|null $title
  * @property string|null $link
- * @property string|null $image
  * @property string|null $summary
  * @property string|null $content
  * @property string|null $author

--- a/src/Transform/Atom.php
+++ b/src/Transform/Atom.php
@@ -50,11 +50,6 @@ final class Atom
                     ->add("<published>{$article->published_at->toAtomString()}</published>");
             }
 
-            // Logo
-            if ($article->image) {
-                $entry->add("<logo><![CDATA[{$article->image}]]></logo>");
-            }
-
             // Author
             if ($article->author) {
                 $entry->add("<author><name>{$article->author}</name></author>");

--- a/tests/Relay/Parsing/NwslTest.php
+++ b/tests/Relay/Parsing/NwslTest.php
@@ -43,12 +43,12 @@ class NwslTest extends TestCase
         $this->assertEquals('57a350e9-eafe-4eb9-b5fb-cb71b4997a74', $article->key);
         $this->assertEquals('2024-25 NWSL Offseason Transaction Tracker', $article->title);
         $this->assertEquals('https://www.nwslsoccer.com/news/2024-25-nwsl-offseason-transaction-tracker', $article->link);
-        $this->assertEquals('https://www.nwslsoccer.com/_next/image?url=https%3A%2F%2Fimages.nwslsoccer.com%2Fimage%2Fprivate%2Ft_ratio21_9-size60%2Fprd%2Fjictgf8szeefvgqmos9e&w=1920&q=75', $article->image);
         $this->assertEquals($summary, $article->summary);
         $this->assertEquals('NWSL Communications', $article->author);
         $this->assertNotNull($article->published_at);
 
         $this->assertStringContainsString("<p>Stay up-to-date with the latest NWSL offseason moves.</p>\n", $article->content);
+        $this->assertStringContainsString("https://www.nwslsoccer.com/_next/image?url=https%3A%2F%2Fimages.nwslsoccer.com%2Fimage%2Fprivate%2Ft_ratio21_9-size60%2Fprd%2Fjictgf8szeefvgqmos9e&w=1920&q=75", $article->content);
     }
 
     #[Test]


### PR DESCRIPTION
It doesn't make sense to keep track of featured images for articles as a separate resource.  This PR removes them from the database and instead inserts them into the content body where applicable.