### PR TITLE
Switch feed content type back to text/xml

### DIFF
--- a/app/Http/Controllers/FeedController.php
+++ b/app/Http/Controllers/FeedController.php
@@ -27,7 +27,7 @@ class FeedController extends Controller
             ->get();
 
         return response((new Atom($site, $articles))->__toString(), 200, [
-            'Content-Type' => 'application/rss+xml',
+            'Content-Type' => 'text/xml',
         ]);
     }
 }


### PR DESCRIPTION
This PR switches the RSS content-type back to "text/xml".   "application/rss+xml" is the preferred type for RSS feeds, but it has proven to be harder to debug feed content with that content type.